### PR TITLE
feat: MIME type tracking

### DIFF
--- a/cmd/tiros/cmd_probe_kubo.go
+++ b/cmd/tiros/cmd_probe_kubo.go
@@ -380,6 +380,7 @@ func probeKuboAction(ctx context.Context, cmd *cli.Command) error {
 					KuboVersion:          kuboVersion.Version,
 					KuboPeerID:           kuboID.ID,
 					FileSizeB:            int32(dr.FileSize),
+					MIMEType:             dr.MIMEType,
 					CID:                  ciid.String(),
 					IPFSCatStart:         dr.IPFSCatStart,
 					IPFSCatDurationS:     dr.IPFSCatEnd.Sub(dr.IPFSCatStart).Seconds(),

--- a/go.mod
+++ b/go.mod
@@ -105,6 +105,7 @@ require (
 	github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2 // indirect
 	github.com/guillaumemichel/reservedpool v0.3.0 // indirect
+	github.com/h2non/filetype v1.1.3 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -335,6 +335,8 @@ github.com/guillaumemichel/reservedpool v0.3.0 h1:eqqO/QvTllLBrit7LVtVJBqw4cD0Wd
 github.com/guillaumemichel/reservedpool v0.3.0/go.mod h1:sXSDIaef81TFdAJglsCFCMfgF5E5Z5xK1tFhjDhvbUc=
 github.com/gxed/hashland/keccakpg v0.0.1/go.mod h1:kRzw3HkwxFU1mpmPP8v1WyQzwdGfmKFJ6tItnhQ67kU=
 github.com/gxed/hashland/murmur3 v0.0.1/go.mod h1:KjXop02n4/ckmZSnY2+HKcLud/tcmvhST0bie/0lS48=
+github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=
+github.com/h2non/filetype v1.1.3/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/pkg/db/db_models.go
+++ b/pkg/db/db_models.go
@@ -29,6 +29,7 @@ type DownloadModel struct {
 	KuboVersion          string     `ch:"kubo_version"`
 	KuboPeerID           string     `ch:"kubo_peer_id"`
 	FileSizeB            int32      `ch:"file_size_b"`
+	MIMEType             string     `ch:"mime_type"`
 	CID                  string     `ch:"cid"`
 	IPFSCatStart         time.Time  `ch:"ipfs_cat_start"`
 	IPFSCatDurationS     float64    `ch:"ipfs_cat_duration_s"`

--- a/pkg/db/migrations/000011_add_mime_type_column_to_downloads_table.down.sql
+++ b/pkg/db/migrations/000011_add_mime_type_column_to_downloads_table.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE downloads
+    DROP COLUMN IF EXISTS mime_type;

--- a/pkg/db/migrations/000011_add_mime_type_column_to_downloads_table.up.sql
+++ b/pkg/db/migrations/000011_add_mime_type_column_to_downloads_table.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE downloads
+    ADD COLUMN IF NOT EXISTS mime_type LowCardinality(Nullable(String)) AFTER file_size_b;

--- a/pkg/kubo/kubo.go
+++ b/pkg/kubo/kubo.go
@@ -338,7 +338,7 @@ func (k *Kubo) Download(ctx context.Context, c cid.Cid) (*DownloadResult, error)
 	}
 	downloadEnd := time.Now()
 
-	data = append(data, buf[:]...)
+	data = append(buf[:], data...)
 	downloadSpan.End()
 
 	logEntry.With("size", len(data)).Info("Read all data")

--- a/pkg/kubo/kubo.go
+++ b/pkg/kubo/kubo.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/h2non/filetype"
 	"github.com/ipfs/boxo/files"
 	"github.com/ipfs/go-cid"
 	ipfs "github.com/ipfs/kubo"
@@ -330,7 +331,7 @@ func (k *Kubo) Download(ctx context.Context, c cid.Cid) (*DownloadResult, error)
 	logEntry.Info("Read first byte")
 	ttfb := time.Since(result.IPFSCatStart)
 
-	r := io.LimitReader(resp.Output, 100*1024*1024) // read at most 20 MiB
+	r := io.LimitReader(resp.Output, 100*1024*1024) // read at most 100 MiB
 	data, err := io.ReadAll(r)
 	if err != nil {
 		return result, err
@@ -350,6 +351,12 @@ func (k *Kubo) Download(ctx context.Context, c cid.Cid) (*DownloadResult, error)
 	result.IPFSCatEnd = downloadEnd
 	result.IPFSCatTTFB = ttfb
 	result.FileSize = len(data)
+
+	// Only the first 262 bytes representing the max file header are required
+	// Src: https://github.com/h2non/filetype - if err != nil, t is types.Unknown
+	// where t.MIME.Value is the empty string.
+	t, _ := filetype.Get(data[:min(262, len(data))])
+	result.MIMEType = t.MIME.Value
 
 	// the FirstBlockReceivedAt field is only used to determine
 	// the discovery method. This field will only be set though,

--- a/pkg/kubo/trace_parse.go
+++ b/pkg/kubo/trace_parse.go
@@ -84,6 +84,7 @@ type DownloadResult struct {
 	IPFSCatEnd   time.Time
 	IPFSCatTTFB  time.Duration
 	FileSize     int
+	MIMEType     string
 
 	IdleBroadcastStartedAt        time.Time
 	FoundProvidersCount           int


### PR DESCRIPTION
Tracks the MIME type of downloaded content during Kubo probes.

## Changes

- **DB migration**: adds a `mime_type` column to the downloads table (migration `000011`)
- **MIME detection**: uses the `h2non/filetype` library to detect the content type from the first 262 bytes of downloaded data
- **Data model**: adds `MIMEType` field to `DownloadResult` and `DownloadModel`
- **Bug fix**: corrects byte-order in data concatenation — first-byte buffer was appended after the body instead of prepended