### PR TITLE
Enhanced server timing header handling

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -16,7 +16,9 @@
       "WebFetch(domain:chromedevtools.github.io)",
       "WebSearch",
       "Bash(./tiros:*)",
-      "Bash(curl:*)"
+      "Bash(curl:*)",
+      "Bash(gh pr:*)",
+      "Bash(go vet *)"
     ],
     "deny": [],
     "ask": []

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.25.1
+golang 1.26.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25 AS builder
+FROM golang:1.26.2 AS builder
 
 WORKDIR /build
 

--- a/cmd/tiros/cmd_probe_serviceworker.go
+++ b/cmd/tiros/cmd_probe_serviceworker.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -11,7 +10,6 @@ import (
 	"net"
 	"net/url"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/chromedp/chromedp"
@@ -303,18 +301,24 @@ func probeServiceWorkerAction(ctx context.Context, cmd *cli.Command) error {
 				dbModel.DelegatedRouterTTFBS = toPtr(result.DelegatedRouterTTFB.Seconds())
 				dbModel.TrustlessGatewayTTFBS = toPtr(result.TrustlessGatewayTTFB.Seconds())
 
-				// Server timings as JSON
-				serverTimings := make(map[string]float64, len(result.ServerTimings))
-				for k, v := range result.ServerTimings {
-					// every dot in the key increases the nesting level in how
-					// clickhouse interprets these keys. Therefore, we replace
-					// them with an _.
-					k = strings.ReplaceAll(k, ".", "_")
-					serverTimings[k] = v.Value.Seconds()
-				}
-				if data, err := json.Marshal(serverTimings); err == nil {
-					dbModel.ServerTimings = data
-				}
+				// Parse server timings into parallel arrays for the Nested column
+				// and compute hot-path scalar projections.
+				stRow := sw.ParseServerTimings(result.ServerTimings)
+				dbModel.ServerTimingName = stRow.NameArr
+				dbModel.ServerTimingDurS = stRow.DurSArr
+				dbModel.ServerTimingRouter = stRow.RouterArr
+				dbModel.ServerTimingBroker = stRow.BrokerArr
+				dbModel.ServerTimingProviderID = stRow.ProviderIDArr
+				dbModel.ServerTimingTransport = stRow.TransportArr
+				dbModel.ServerTimingExtra = stRow.ExtraArr
+				dbModel.STIPFSResolveS = stRow.IPFSResolveS
+				dbModel.STDNSLinkResolveS = stRow.DNSLinkResolveS
+				dbModel.STIPNSResolveS = stRow.IPNSResolveS
+				dbModel.STFirstConnectS = stRow.FirstConnectS
+				dbModel.STFirstBlockS = stRow.FirstBlockS
+				dbModel.STProviderCountHTTPGateway = stRow.ProviderCountHTTPGateway
+				dbModel.STProviderCountLibp2p = stRow.ProviderCountLibp2p
+				dbModel.STFastestBlockBroker = stRow.FastestBlockBroker
 			}
 
 			slog.With(
@@ -322,7 +326,8 @@ func probeServiceWorkerAction(ctx context.Context, cmd *cli.Command) error {
 				"status", dbModel.StatusCode,
 				"totalTTFBs", deref(dbModel.TotalTTFBS),
 				"finalTTFBs", deref(dbModel.FinalTTFBS),
-				"serverTimings", string(dbModel.ServerTimings),
+				"stFirstBlockS", deref(dbModel.STFirstBlockS),
+				"serverTimingCount", len(dbModel.ServerTimingName),
 				"cid", ciid.String(),
 			).Info("Inserting service worker probe into database")
 

--- a/cmd/tiros/cmd_probe_serviceworker.go
+++ b/cmd/tiros/cmd_probe_serviceworker.go
@@ -306,8 +306,7 @@ func probeServiceWorkerAction(ctx context.Context, cmd *cli.Command) error {
 				stRow := sw.ParseServerTimings(result.ServerTimings)
 				dbModel.ServerTimingName = stRow.NameArr
 				dbModel.ServerTimingDurS = stRow.DurSArr
-				dbModel.ServerTimingRouter = stRow.RouterArr
-				dbModel.ServerTimingBroker = stRow.BrokerArr
+				dbModel.ServerTimingSystem = stRow.SystemArr
 				dbModel.ServerTimingProviderID = stRow.ProviderIDArr
 				dbModel.ServerTimingTransport = stRow.TransportArr
 				dbModel.ServerTimingExtra = stRow.ExtraArr
@@ -318,7 +317,7 @@ func probeServiceWorkerAction(ctx context.Context, cmd *cli.Command) error {
 				dbModel.STFirstBlockS = stRow.FirstBlockS
 				dbModel.STProviderCountHTTPGateway = stRow.ProviderCountHTTPGateway
 				dbModel.STProviderCountLibp2p = stRow.ProviderCountLibp2p
-				dbModel.STFastestBlockBroker = stRow.FastestBlockBroker
+				dbModel.STFastestBlockSystem = stRow.FastestBlockSystem
 			}
 
 			slog.With(

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,12 @@
 module github.com/probe-lab/tiros
 
-go 1.25.1
+go 1.26.1
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.40.3
 	github.com/chromedp/cdproto v0.0.0-20250319231242-a755498943c8
 	github.com/chromedp/chromedp v0.13.2
+	github.com/dennis-tra/go-server-timing v0.0.0-20260424074312-0a76ef9fc7a7
 	github.com/gabriel-vasile/mimetype v1.4.10
 	github.com/go-rod/rod v0.116.2
 	github.com/google/uuid v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b // indirect
 	github.com/cockroachdb/pebble/v2 v2.1.2 // indirect
 	github.com/cockroachdb/redact v1.1.5 // indirect
-	github.com/cockroachdb/swiss v0.0.0-20250624142022-d6e517c1d961 // indirect
+	github.com/cockroachdb/swiss v0.0.0-20251224182025-b0f6560f979b // indirect
 	github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 // indirect
 	github.com/crackcomm/go-gitignore v0.0.0-20241020182519-7843d2ba8fdf // indirect
 	github.com/cskr/pubsub v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -154,6 +154,8 @@ github.com/decred/dcrd/crypto/blake256 v1.1.0 h1:zPMNGQCm0g4QTY27fOCorQW7EryeQ/U
 github.com/decred/dcrd/crypto/blake256 v1.1.0/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 h1:NMZiJj8QnKe1LgsbDayM4UoHwbvwDRwnI3hwNaAHRnc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0/go.mod h1:ZXNYxsqcloTdSy/rNShjYzMhyjf0LaoftYK0p+A3h40=
+github.com/dennis-tra/go-server-timing v0.0.0-20260424074312-0a76ef9fc7a7 h1:w+rhkHqL2s1iO/RbjsJ93ltiy/trK7L5Li0jdClJNKo=
+github.com/dennis-tra/go-server-timing v0.0.0-20260424074312-0a76ef9fc7a7/go.mod h1:GuNU9tVMXFAf05hzg8ARvdlhzyUY25RPEDS55+DLrQY=
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
 github.com/dgraph-io/badger v1.6.2 h1:mNw0qs90GVgGGWylh0umH5iag1j6n/PeJtNvL6KY/x8=
 github.com/dgraph-io/badger v1.6.2/go.mod h1:JW2yswe3V058sS0kZ2h/AXeDSqFjxnZcRrVH//y2UQE=

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/cockroachdb/pebble/v2 v2.1.2 h1:IwYt+Y2Cdw6egblwk1kWzdmJvD2680t5VK/3i
 github.com/cockroachdb/pebble/v2 v2.1.2/go.mod h1:Aza05DCCc05ghIJZkB4Q/axv/JK9wx5cFwWcnhG0eGw=
 github.com/cockroachdb/redact v1.1.5 h1:u1PMllDkdFfPWaNGMyLD1+so+aq3uUItthCFqzwPJ30=
 github.com/cockroachdb/redact v1.1.5/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
-github.com/cockroachdb/swiss v0.0.0-20250624142022-d6e517c1d961 h1:Nua446ru3juLHLZd4AwKNzClZgL1co3pUPGv3o8FlcA=
-github.com/cockroachdb/swiss v0.0.0-20250624142022-d6e517c1d961/go.mod h1:yBRu/cnL4ks9bgy4vAASdjIW+/xMlFwuHKqtmh3GZQg=
+github.com/cockroachdb/swiss v0.0.0-20251224182025-b0f6560f979b h1:VXvSNzmr8hMj8XTuY0PT9Ane9qZGul/p67vGYwl9BFI=
+github.com/cockroachdb/swiss v0.0.0-20251224182025-b0f6560f979b/go.mod h1:yBRu/cnL4ks9bgy4vAASdjIW+/xMlFwuHKqtmh3GZQg=
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 h1:zuQyyAKVxetITBuuhv3BI9cMrmStnpT18zmgmTxunpo=
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06/go.mod h1:7nc4anLGjupUW/PeY5qiNYsdNXj7zopG+eqsS7To5IQ=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=

--- a/pkg/db/db_models.go
+++ b/pkg/db/db_models.go
@@ -171,8 +171,7 @@ type ServiceWorkerProbeModel struct {
 	// Single-letter abbreviations from the wire format are expanded to readable names.
 	ServerTimingName       []string  `ch:"server_timing.name"`        // Metric: dnslink_resolve|ipfs_resolve|ipns_resolve|provider|find_providers|connect|block
 	ServerTimingDurS       []float64 `ch:"server_timing.dur_s"`       // Metric duration in seconds
-	ServerTimingRouter     []string  `ch:"server_timing.router"`      // http_gateway|libp2p for provider/find_providers; empty otherwise
-	ServerTimingBroker     []string  `ch:"server_timing.broker"`      // trustless_gateway|bitswap for connect/block; empty otherwise
+	ServerTimingSystem     []string  `ch:"server_timing.system"`      // Subsystem: http_gateway|libp2p (for provider/find_providers) or trustless_gateway|bitswap (for connect/block); empty otherwise
 	ServerTimingProviderID []string  `ch:"server_timing.provider_id"` // Provider ID for provider/connect/block; empty otherwise
 	ServerTimingTransport  []string  `ch:"server_timing.transport"`   // tcp|http|websockets|webrtc|webrtc_direct|quic|webtransport|unknown for connect; empty otherwise
 	ServerTimingExtra      []string  `ch:"server_timing.extra"`       // Trailing desc payload: count for find_providers, cid for block; empty otherwise
@@ -184,9 +183,9 @@ type ServiceWorkerProbeModel struct {
 	STIPNSResolveS             *float64 `ch:"st_ipns_resolve_s"`              // Duration of the ipns_resolve metric (seconds)
 	STFirstConnectS            *float64 `ch:"st_first_connect_s"`             // Fastest connect duration across providers (seconds)
 	STFirstBlockS              *float64 `ch:"st_first_block_s"`               // Fastest block retrieval duration across providers (seconds)
-	STProviderCountHTTPGateway uint16   `ch:"st_provider_count_http_gateway"` // Number of provider metrics with router=http_gateway
-	STProviderCountLibp2p      uint16   `ch:"st_provider_count_libp2p"`       // Number of provider metrics with router=libp2p
-	STFastestBlockBroker       string   `ch:"st_fastest_block_broker"`        // Broker of the fastest block metric (trustless_gateway|bitswap); empty if none
+	STProviderCountHTTPGateway uint16   `ch:"st_provider_count_http_gateway"` // Number of provider metrics with system=http_gateway
+	STProviderCountLibp2p      uint16   `ch:"st_provider_count_libp2p"`       // Number of provider metrics with system=libp2p
+	STFastestBlockSystem       string   `ch:"st_fastest_block_system"`        // System of the fastest block metric (trustless_gateway|bitswap); empty if none
 
 	// Provider and gateway metrics
 	FoundProviders        int      `ch:"found_providers"`          // Number of unique providers found via delegated routing

--- a/pkg/db/db_models.go
+++ b/pkg/db/db_models.go
@@ -166,9 +166,27 @@ type ServiceWorkerProbeModel struct {
 	IPFSPath  *string `ch:"ipfs_path"`  // IPFS path of the content (from "x-ipfs-path" header)
 	IPFSRoots *string `ch:"ipfs_roots"` // IPFS root CIDs involved in resolution (from "x-ipfs-roots" header)
 
-	// Server timing data (map of timing metrics from service worker)
-	// Contains internal service worker metrics
-	ServerTimings json.RawMessage `ch:"server_timings"`
+	// Server timing data — parallel arrays bound to the Nested `server_timing` column.
+	// All slices must have the same length; absent sub-fields use "" / 0 sentinels.
+	// Single-letter abbreviations from the wire format are expanded to readable names.
+	ServerTimingName       []string  `ch:"server_timing.name"`        // Metric: dnslink_resolve|ipfs_resolve|ipns_resolve|provider|find_providers|connect|block
+	ServerTimingDurS       []float64 `ch:"server_timing.dur_s"`       // Metric duration in seconds
+	ServerTimingRouter     []string  `ch:"server_timing.router"`      // http_gateway|libp2p for provider/find_providers; empty otherwise
+	ServerTimingBroker     []string  `ch:"server_timing.broker"`      // trustless_gateway|bitswap for connect/block; empty otherwise
+	ServerTimingProviderID []string  `ch:"server_timing.provider_id"` // Provider ID for provider/connect/block; empty otherwise
+	ServerTimingTransport  []string  `ch:"server_timing.transport"`   // tcp|http|websockets|webrtc|webrtc_direct|quic|webtransport|unknown for connect; empty otherwise
+	ServerTimingExtra      []string  `ch:"server_timing.extra"`       // Trailing desc payload: count for find_providers, cid for block; empty otherwise
+
+	// Hot-path scalar projections of the server timings for cheap dashboard queries.
+	// All st_* columns are derived from the Server-Timing header above.
+	STIPFSResolveS             *float64 `ch:"st_ipfs_resolve_s"`              // Duration of the ipfs_resolve metric (seconds)
+	STDNSLinkResolveS          *float64 `ch:"st_dnslink_resolve_s"`           // Duration of the dnslink_resolve metric (seconds)
+	STIPNSResolveS             *float64 `ch:"st_ipns_resolve_s"`              // Duration of the ipns_resolve metric (seconds)
+	STFirstConnectS            *float64 `ch:"st_first_connect_s"`             // Fastest connect duration across providers (seconds)
+	STFirstBlockS              *float64 `ch:"st_first_block_s"`               // Fastest block retrieval duration across providers (seconds)
+	STProviderCountHTTPGateway uint16   `ch:"st_provider_count_http_gateway"` // Number of provider metrics with router=http_gateway
+	STProviderCountLibp2p      uint16   `ch:"st_provider_count_libp2p"`       // Number of provider metrics with router=libp2p
+	STFastestBlockBroker       string   `ch:"st_fastest_block_broker"`        // Broker of the fastest block metric (trustless_gateway|bitswap); empty if none
 
 	// Provider and gateway metrics
 	FoundProviders        int      `ch:"found_providers"`          // Number of unique providers found via delegated routing

--- a/pkg/db/db_models.go
+++ b/pkg/db/db_models.go
@@ -166,15 +166,15 @@ type ServiceWorkerProbeModel struct {
 	IPFSPath  *string `ch:"ipfs_path"`  // IPFS path of the content (from "x-ipfs-path" header)
 	IPFSRoots *string `ch:"ipfs_roots"` // IPFS root CIDs involved in resolution (from "x-ipfs-roots" header)
 
-	// Server timing data — parallel arrays bound to the Nested `server_timing` column.
+	// Server timing data — parallel arrays bound to the Nested `server_timing_metrics` column.
 	// All slices must have the same length; absent sub-fields use "" / 0 sentinels.
 	// Single-letter abbreviations from the wire format are expanded to readable names.
-	ServerTimingName       []string  `ch:"server_timing.name"`        // Metric: dnslink_resolve|ipfs_resolve|ipns_resolve|provider|find_providers|connect|block
-	ServerTimingDurS       []float64 `ch:"server_timing.dur_s"`       // Metric duration in seconds
-	ServerTimingSystem     []string  `ch:"server_timing.system"`      // Subsystem: http_gateway|libp2p (for provider/find_providers) or trustless_gateway|bitswap (for connect/block); empty otherwise
-	ServerTimingProviderID []string  `ch:"server_timing.provider_id"` // Provider ID for provider/connect/block; empty otherwise
-	ServerTimingTransport  []string  `ch:"server_timing.transport"`   // tcp|http|websockets|webrtc|webrtc_direct|quic|webtransport|unknown for connect; empty otherwise
-	ServerTimingExtra      []string  `ch:"server_timing.extra"`       // Trailing desc payload: count for find_providers, cid for block; empty otherwise
+	ServerTimingName       []string  `ch:"server_timing_metrics.name"`        // Metric: dnslink_resolve|ipfs_resolve|ipns_resolve|provider|find_providers|connect|block
+	ServerTimingDurS       []float64 `ch:"server_timing_metrics.duration_s"`  // Metric duration in seconds
+	ServerTimingSystem     []string  `ch:"server_timing_metrics.system"`      // Subsystem: http_gateway|libp2p (for provider/find_providers) or trustless_gateway|bitswap (for connect/block); empty otherwise
+	ServerTimingProviderID []string  `ch:"server_timing_metrics.provider_id"` // Provider ID for provider/connect/block; empty otherwise
+	ServerTimingTransport  []string  `ch:"server_timing_metrics.transport"`   // tcp|http|websockets|webrtc|webrtc_direct|quic|webtransport|unknown for connect; empty otherwise
+	ServerTimingExtra      []string  `ch:"server_timing_metrics.extra"`       // Trailing desc payload: count for find_providers, cid for block; empty otherwise
 
 	// Hot-path scalar projections of the server timings for cheap dashboard queries.
 	// All st_* columns are derived from the Server-Timing header above.

--- a/pkg/db/migrations/000012_add_server_timing_to_service_worker_probes_table.down.sql
+++ b/pkg/db/migrations/000012_add_server_timing_to_service_worker_probes_table.down.sql
@@ -1,0 +1,11 @@
+ALTER TABLE service_worker_probes
+    DROP COLUMN IF EXISTS server_timing,
+    DROP COLUMN IF EXISTS st_ipfs_resolve_s,
+    DROP COLUMN IF EXISTS st_dnslink_resolve_s,
+    DROP COLUMN IF EXISTS st_ipns_resolve_s,
+    DROP COLUMN IF EXISTS st_first_connect_s,
+    DROP COLUMN IF EXISTS st_first_block_s,
+    DROP COLUMN IF EXISTS st_provider_count_http_gateway,
+    DROP COLUMN IF EXISTS st_provider_count_libp2p,
+    DROP COLUMN IF EXISTS st_fastest_block_broker,
+    ADD COLUMN IF NOT EXISTS server_timings JSON() COMMENT 'Map of service worker internal timing metrics';

--- a/pkg/db/migrations/000012_add_server_timing_to_service_worker_probes_table.down.sql
+++ b/pkg/db/migrations/000012_add_server_timing_to_service_worker_probes_table.down.sql
@@ -7,5 +7,5 @@ ALTER TABLE service_worker_probes
     DROP COLUMN IF EXISTS st_first_block_s,
     DROP COLUMN IF EXISTS st_provider_count_http_gateway,
     DROP COLUMN IF EXISTS st_provider_count_libp2p,
-    DROP COLUMN IF EXISTS st_fastest_block_broker,
+    DROP COLUMN IF EXISTS st_fastest_block_system,
     ADD COLUMN IF NOT EXISTS server_timings JSON() COMMENT 'Map of service worker internal timing metrics';

--- a/pkg/db/migrations/000012_add_server_timing_to_service_worker_probes_table.down.sql
+++ b/pkg/db/migrations/000012_add_server_timing_to_service_worker_probes_table.down.sql
@@ -7,5 +7,4 @@ ALTER TABLE service_worker_probes
     DROP COLUMN IF EXISTS st_first_block_s,
     DROP COLUMN IF EXISTS st_provider_count_http_gateway,
     DROP COLUMN IF EXISTS st_provider_count_libp2p,
-    DROP COLUMN IF EXISTS st_fastest_block_system,
-    ADD COLUMN IF NOT EXISTS server_timings JSON() COMMENT 'Map of service worker internal timing metrics';
+    DROP COLUMN IF EXISTS st_fastest_block_system;

--- a/pkg/db/migrations/000012_add_server_timing_to_service_worker_probes_table.up.sql
+++ b/pkg/db/migrations/000012_add_server_timing_to_service_worker_probes_table.up.sql
@@ -3,17 +3,16 @@ ALTER TABLE service_worker_probes
     ADD COLUMN IF NOT EXISTS server_timing Nested(
         name        LowCardinality(String),
         dur_s       Float64,
-        router      LowCardinality(String),
-        broker      LowCardinality(String),
+        system      LowCardinality(String),
         provider_id String,
         transport   LowCardinality(String),
         extra       String
-    ) COMMENT 'Per-metric Server-Timing entries parsed from the final response. Abbreviations expanded to readable names: name in (dnslink_resolve|ipfs_resolve|ipns_resolve|provider|find_providers|connect|block); router in (http_gateway|libp2p); broker in (trustless_gateway|bitswap); transport in (tcp|http|websockets|webrtc|webrtc_direct|quic|webtransport|unknown). Preserves duplicates and order.',
+    ) COMMENT 'Per-metric Server-Timing entries parsed from the final response. Abbreviations expanded to readable names: name in (dnslink_resolve|ipfs_resolve|ipns_resolve|provider|find_providers|connect|block); system in (http_gateway|libp2p|trustless_gateway|bitswap) — discovery subsystem for provider/find_providers, retrieval subsystem for connect/block; transport in (tcp|http|websockets|webrtc|webrtc_direct|quic|webtransport|unknown). Preserves duplicates and order.',
     ADD COLUMN IF NOT EXISTS st_ipfs_resolve_s              Nullable(Float64)      COMMENT 'Duration of the ipfs_resolve metric (seconds); derived from server_timing',
     ADD COLUMN IF NOT EXISTS st_dnslink_resolve_s           Nullable(Float64)      COMMENT 'Duration of the dnslink_resolve metric (seconds); derived from server_timing',
     ADD COLUMN IF NOT EXISTS st_ipns_resolve_s              Nullable(Float64)      COMMENT 'Duration of the ipns_resolve metric (seconds); derived from server_timing',
     ADD COLUMN IF NOT EXISTS st_first_connect_s             Nullable(Float64)      COMMENT 'Fastest connect duration across all providers (seconds); derived from server_timing',
     ADD COLUMN IF NOT EXISTS st_first_block_s               Nullable(Float64)      COMMENT 'Fastest block retrieval duration across all providers (seconds); derived from server_timing',
-    ADD COLUMN IF NOT EXISTS st_provider_count_http_gateway UInt16                 COMMENT 'Number of provider metrics with router=http_gateway; derived from server_timing',
-    ADD COLUMN IF NOT EXISTS st_provider_count_libp2p       UInt16                 COMMENT 'Number of provider metrics with router=libp2p; derived from server_timing',
-    ADD COLUMN IF NOT EXISTS st_fastest_block_broker        LowCardinality(String) COMMENT 'Broker (trustless_gateway|bitswap) of the block metric with the fastest duration; empty if none; derived from server_timing';
+    ADD COLUMN IF NOT EXISTS st_provider_count_http_gateway UInt16                 COMMENT 'Number of provider metrics with system=http_gateway; derived from server_timing',
+    ADD COLUMN IF NOT EXISTS st_provider_count_libp2p       UInt16                 COMMENT 'Number of provider metrics with system=libp2p; derived from server_timing',
+    ADD COLUMN IF NOT EXISTS st_fastest_block_system        LowCardinality(String) COMMENT 'System of the block metric with the fastest duration (trustless_gateway|bitswap); empty if none; derived from server_timing';

--- a/pkg/db/migrations/000012_add_server_timing_to_service_worker_probes_table.up.sql
+++ b/pkg/db/migrations/000012_add_server_timing_to_service_worker_probes_table.up.sql
@@ -1,8 +1,7 @@
 ALTER TABLE service_worker_probes
-    DROP COLUMN IF EXISTS server_timings,
-    ADD COLUMN IF NOT EXISTS server_timing Nested(
+    ADD COLUMN IF NOT EXISTS server_timing_metrics Nested(
         name        LowCardinality(String),
-        dur_s       Float64,
+        duration_s  Float64,
         system      LowCardinality(String),
         provider_id String,
         transport   LowCardinality(String),

--- a/pkg/db/migrations/000012_add_server_timing_to_service_worker_probes_table.up.sql
+++ b/pkg/db/migrations/000012_add_server_timing_to_service_worker_probes_table.up.sql
@@ -1,0 +1,19 @@
+ALTER TABLE service_worker_probes
+    DROP COLUMN IF EXISTS server_timings,
+    ADD COLUMN IF NOT EXISTS server_timing Nested(
+        name        LowCardinality(String),
+        dur_s       Float64,
+        router      LowCardinality(String),
+        broker      LowCardinality(String),
+        provider_id String,
+        transport   LowCardinality(String),
+        extra       String
+    ) COMMENT 'Per-metric Server-Timing entries parsed from the final response. Abbreviations expanded to readable names: name in (dnslink_resolve|ipfs_resolve|ipns_resolve|provider|find_providers|connect|block); router in (http_gateway|libp2p); broker in (trustless_gateway|bitswap); transport in (tcp|http|websockets|webrtc|webrtc_direct|quic|webtransport|unknown). Preserves duplicates and order.',
+    ADD COLUMN IF NOT EXISTS st_ipfs_resolve_s              Nullable(Float64)      COMMENT 'Duration of the ipfs_resolve metric (seconds); derived from server_timing',
+    ADD COLUMN IF NOT EXISTS st_dnslink_resolve_s           Nullable(Float64)      COMMENT 'Duration of the dnslink_resolve metric (seconds); derived from server_timing',
+    ADD COLUMN IF NOT EXISTS st_ipns_resolve_s              Nullable(Float64)      COMMENT 'Duration of the ipns_resolve metric (seconds); derived from server_timing',
+    ADD COLUMN IF NOT EXISTS st_first_connect_s             Nullable(Float64)      COMMENT 'Fastest connect duration across all providers (seconds); derived from server_timing',
+    ADD COLUMN IF NOT EXISTS st_first_block_s               Nullable(Float64)      COMMENT 'Fastest block retrieval duration across all providers (seconds); derived from server_timing',
+    ADD COLUMN IF NOT EXISTS st_provider_count_http_gateway UInt16                 COMMENT 'Number of provider metrics with router=http_gateway; derived from server_timing',
+    ADD COLUMN IF NOT EXISTS st_provider_count_libp2p       UInt16                 COMMENT 'Number of provider metrics with router=libp2p; derived from server_timing',
+    ADD COLUMN IF NOT EXISTS st_fastest_block_broker        LowCardinality(String) COMMENT 'Broker (trustless_gateway|bitswap) of the block metric with the fastest duration; empty if none; derived from server_timing';

--- a/pkg/sw/server_timing.go
+++ b/pkg/sw/server_timing.go
@@ -21,16 +21,14 @@ const (
 	metricBlock          = "block"
 )
 
-// Router: h|l.
+// Subsystem values. Routers (h|l) apply to provider/find_providers metrics;
+// brokers (t|b) apply to connect/block metrics. The abbreviations don't
+// collide across those positions, so a single unified lookup table is safe.
 const (
-	routerHTTPGateway = "http_gateway"
-	routerLibp2p      = "libp2p"
-)
-
-// Block broker: t|b.
-const (
-	brokerTrustlessGateway = "trustless_gateway"
-	brokerBitswap          = "bitswap"
+	systemHTTPGateway      = "http_gateway"
+	systemLibp2p           = "libp2p"
+	systemTrustlessGateway = "trustless_gateway"
+	systemBitswap          = "bitswap"
 )
 
 var metricNames = map[string]string{
@@ -43,14 +41,11 @@ var metricNames = map[string]string{
 	"b": metricBlock,
 }
 
-var routerNames = map[string]string{
-	"h": routerHTTPGateway,
-	"l": routerLibp2p,
-}
-
-var brokerNames = map[string]string{
-	"t": brokerTrustlessGateway,
-	"b": brokerBitswap,
+var systemNames = map[string]string{
+	"h": systemHTTPGateway,      // router, only valid for p/f
+	"l": systemLibp2p,           // router, only valid for p/f
+	"t": systemTrustlessGateway, // broker, only valid for c/b
+	"b": systemBitswap,          // broker, only valid for c/b
 }
 
 var transportNames = map[string]string{
@@ -77,11 +72,13 @@ var transportNames = map[string]string{
 //	f     : desc="router,count"  // find-providers total per routing system
 //	c     : desc="broker,pid,t"  // connect (broker: t|b, t: transport)
 //	b     : desc="broker,pid,cid"// block retrieved
+//
+// router and broker are merged into a single `system` column since they never
+// co-occur on the same metric; the metric name carries the lifecycle stage.
 type ServerTimingRow struct {
 	NameArr       []string
 	DurSArr       []float64
-	RouterArr     []string
-	BrokerArr     []string
+	SystemArr     []string
 	ProviderIDArr []string
 	TransportArr  []string
 	ExtraArr      []string
@@ -93,7 +90,7 @@ type ServerTimingRow struct {
 	FirstBlockS              *float64
 	ProviderCountHTTPGateway uint16
 	ProviderCountLibp2p      uint16
-	FastestBlockBroker       string
+	FastestBlockSystem       string
 }
 
 // ParseServerTimings converts a slice of server-timing metrics into a ServerTimingRow.
@@ -104,8 +101,7 @@ func ParseServerTimings(metrics []*servertiming.Metric) ServerTimingRow {
 	row := ServerTimingRow{
 		NameArr:       make([]string, 0, len(metrics)),
 		DurSArr:       make([]float64, 0, len(metrics)),
-		RouterArr:     make([]string, 0, len(metrics)),
-		BrokerArr:     make([]string, 0, len(metrics)),
+		SystemArr:     make([]string, 0, len(metrics)),
 		ProviderIDArr: make([]string, 0, len(metrics)),
 		TransportArr:  make([]string, 0, len(metrics)),
 		ExtraArr:      make([]string, 0, len(metrics)),
@@ -118,27 +114,27 @@ func ParseServerTimings(metrics []*servertiming.Metric) ServerTimingRow {
 
 		name := expand(metricNames, m.Name)
 		dur := m.Duration.Seconds()
-		var router, broker, providerID, transport, extra string
+		var system, providerID, transport, extra string
 
 		// desc semantics depend on the raw metric name (the single letter).
 		parts := splitDesc(m.Description)
 		switch m.Name {
 		case "p":
 			// desc="router,providerId"
-			router = expand(routerNames, get(parts, 0))
+			system = expand(systemNames, get(parts, 0))
 			providerID = get(parts, 1)
 		case "f":
 			// desc="router,count"
-			router = expand(routerNames, get(parts, 0))
+			system = expand(systemNames, get(parts, 0))
 			extra = get(parts, 1)
 		case "c":
 			// desc="broker,providerId,transport"
-			broker = expand(brokerNames, get(parts, 0))
+			system = expand(systemNames, get(parts, 0))
 			providerID = get(parts, 1)
 			transport = expand(transportNames, get(parts, 2))
 		case "b":
 			// desc="broker,providerId,cid"
-			broker = expand(brokerNames, get(parts, 0))
+			system = expand(systemNames, get(parts, 0))
 			providerID = get(parts, 1)
 			extra = get(parts, 2)
 		default:
@@ -147,8 +143,7 @@ func ParseServerTimings(metrics []*servertiming.Metric) ServerTimingRow {
 
 		row.NameArr = append(row.NameArr, name)
 		row.DurSArr = append(row.DurSArr, dur)
-		row.RouterArr = append(row.RouterArr, router)
-		row.BrokerArr = append(row.BrokerArr, broker)
+		row.SystemArr = append(row.SystemArr, system)
 		row.ProviderIDArr = append(row.ProviderIDArr, providerID)
 		row.TransportArr = append(row.TransportArr, transport)
 		row.ExtraArr = append(row.ExtraArr, extra)
@@ -174,13 +169,13 @@ func ParseServerTimings(metrics []*servertiming.Metric) ServerTimingRow {
 		case "b":
 			if row.FirstBlockS == nil || dur < *row.FirstBlockS {
 				row.FirstBlockS = new(dur)
-				row.FastestBlockBroker = broker
+				row.FastestBlockSystem = system
 			}
 		case "p":
-			switch router {
-			case routerHTTPGateway:
+			switch system {
+			case systemHTTPGateway:
 				row.ProviderCountHTTPGateway++
-			case routerLibp2p:
+			case systemLibp2p:
 				row.ProviderCountLibp2p++
 			}
 		}

--- a/pkg/sw/server_timing.go
+++ b/pkg/sw/server_timing.go
@@ -1,0 +1,217 @@
+package sw
+
+import (
+	"strings"
+
+	servertiming "github.com/dennis-tra/go-server-timing"
+)
+
+// Server-Timing abbreviation tables from the helia-verified-fetch README.
+// Stored in the DB as their expanded names so queries are self-documenting.
+// Unknown abbreviations pass through verbatim (forward-compat with new codes).
+
+// Metric names: d|i|n|p|f|c|b.
+const (
+	metricDNSLinkResolve = "dnslink_resolve"
+	metricIPFSResolve    = "ipfs_resolve"
+	metricIPNSResolve    = "ipns_resolve"
+	metricProvider       = "provider"
+	metricFindProviders  = "find_providers"
+	metricConnect        = "connect"
+	metricBlock          = "block"
+)
+
+// Router: h|l.
+const (
+	routerHTTPGateway = "http_gateway"
+	routerLibp2p      = "libp2p"
+)
+
+// Block broker: t|b.
+const (
+	brokerTrustlessGateway = "trustless_gateway"
+	brokerBitswap          = "bitswap"
+)
+
+var metricNames = map[string]string{
+	"d": metricDNSLinkResolve,
+	"i": metricIPFSResolve,
+	"n": metricIPNSResolve,
+	"p": metricProvider,
+	"f": metricFindProviders,
+	"c": metricConnect,
+	"b": metricBlock,
+}
+
+var routerNames = map[string]string{
+	"h": routerHTTPGateway,
+	"l": routerLibp2p,
+}
+
+var brokerNames = map[string]string{
+	"t": brokerTrustlessGateway,
+	"b": brokerBitswap,
+}
+
+var transportNames = map[string]string{
+	"t": "tcp",
+	"h": "http",
+	"w": "websockets",
+	"r": "webrtc",
+	"d": "webrtc_direct",
+	"q": "quic",
+	"b": "webtransport",
+	"u": "unknown",
+}
+
+// ServerTimingRow is the parsed, DB-ready projection of a []*servertiming.Metric.
+// The *Arr slices are parallel (same length, one entry per metric, duplicates preserved,
+// original order retained) and map directly onto the Nested `server_timing` column
+// in the service_worker_probes table. The scalar fields are the hot-path aggregates
+// used by dashboards.
+//
+// Ref grammar (from helia-verified-fetch README):
+//
+//	d/i/n : no desc              // DNSLink / IPFS / IPNS resolve
+//	p     : desc="router,pid"    // provider found (router: h|l)
+//	f     : desc="router,count"  // find-providers total per routing system
+//	c     : desc="broker,pid,t"  // connect (broker: t|b, t: transport)
+//	b     : desc="broker,pid,cid"// block retrieved
+type ServerTimingRow struct {
+	NameArr       []string
+	DurSArr       []float64
+	RouterArr     []string
+	BrokerArr     []string
+	ProviderIDArr []string
+	TransportArr  []string
+	ExtraArr      []string
+
+	IPFSResolveS             *float64
+	DNSLinkResolveS          *float64
+	IPNSResolveS             *float64
+	FirstConnectS            *float64
+	FirstBlockS              *float64
+	ProviderCountHTTPGateway uint16
+	ProviderCountLibp2p      uint16
+	FastestBlockBroker       string
+}
+
+// ParseServerTimings converts a slice of server-timing metrics into a ServerTimingRow.
+// Single-letter abbreviations are expanded to readable names; unknown codes pass through
+// verbatim. Absent sub-fields are filled with "" sentinels so all parallel slices share
+// the same length.
+func ParseServerTimings(metrics []*servertiming.Metric) ServerTimingRow {
+	row := ServerTimingRow{
+		NameArr:       make([]string, 0, len(metrics)),
+		DurSArr:       make([]float64, 0, len(metrics)),
+		RouterArr:     make([]string, 0, len(metrics)),
+		BrokerArr:     make([]string, 0, len(metrics)),
+		ProviderIDArr: make([]string, 0, len(metrics)),
+		TransportArr:  make([]string, 0, len(metrics)),
+		ExtraArr:      make([]string, 0, len(metrics)),
+	}
+
+	for _, m := range metrics {
+		if m == nil {
+			continue
+		}
+
+		name := expand(metricNames, m.Name)
+		dur := m.Duration.Seconds()
+		var router, broker, providerID, transport, extra string
+
+		// desc semantics depend on the raw metric name (the single letter).
+		parts := splitDesc(m.Description)
+		switch m.Name {
+		case "p":
+			// desc="router,providerId"
+			router = expand(routerNames, get(parts, 0))
+			providerID = get(parts, 1)
+		case "f":
+			// desc="router,count"
+			router = expand(routerNames, get(parts, 0))
+			extra = get(parts, 1)
+		case "c":
+			// desc="broker,providerId,transport"
+			broker = expand(brokerNames, get(parts, 0))
+			providerID = get(parts, 1)
+			transport = expand(transportNames, get(parts, 2))
+		case "b":
+			// desc="broker,providerId,cid"
+			broker = expand(brokerNames, get(parts, 0))
+			providerID = get(parts, 1)
+			extra = get(parts, 2)
+		default:
+			// d, i, n — no desc.
+		}
+
+		row.NameArr = append(row.NameArr, name)
+		row.DurSArr = append(row.DurSArr, dur)
+		row.RouterArr = append(row.RouterArr, router)
+		row.BrokerArr = append(row.BrokerArr, broker)
+		row.ProviderIDArr = append(row.ProviderIDArr, providerID)
+		row.TransportArr = append(row.TransportArr, transport)
+		row.ExtraArr = append(row.ExtraArr, extra)
+
+		// Scalar projections — switch on the raw abbreviation since that's the wire form.
+		switch m.Name {
+		case "i":
+			if row.IPFSResolveS == nil {
+				row.IPFSResolveS = new(dur)
+			}
+		case "d":
+			if row.DNSLinkResolveS == nil {
+				row.DNSLinkResolveS = new(dur)
+			}
+		case "n":
+			if row.IPNSResolveS == nil {
+				row.IPNSResolveS = new(dur)
+			}
+		case "c":
+			if row.FirstConnectS == nil || dur < *row.FirstConnectS {
+				row.FirstConnectS = new(dur)
+			}
+		case "b":
+			if row.FirstBlockS == nil || dur < *row.FirstBlockS {
+				row.FirstBlockS = new(dur)
+				row.FastestBlockBroker = broker
+			}
+		case "p":
+			switch router {
+			case routerHTTPGateway:
+				row.ProviderCountHTTPGateway++
+			case routerLibp2p:
+				row.ProviderCountLibp2p++
+			}
+		}
+	}
+
+	return row
+}
+
+// expand returns table[code] if present, otherwise code itself (pass-through for
+// unknown abbreviations so we don't silently drop new Server-Timing codes).
+func expand(table map[string]string, code string) string {
+	if code == "" {
+		return ""
+	}
+	if v, ok := table[code]; ok {
+		return v
+	}
+	return code
+}
+
+// splitDesc splits a Server-Timing desc value by commas. Returns nil for empty input.
+func splitDesc(desc string) []string {
+	if desc == "" {
+		return nil
+	}
+	return strings.Split(desc, ",")
+}
+
+func get(parts []string, idx int) string {
+	if idx < 0 || idx >= len(parts) {
+		return ""
+	}
+	return parts[idx]
+}

--- a/pkg/sw/server_timing_test.go
+++ b/pkg/sw/server_timing_test.go
@@ -34,7 +34,7 @@ func TestParseServerTimings(t *testing.T) {
 		wantFirstBlockS              *float64
 		wantProviderCountHTTPGateway uint16
 		wantProviderCountLibp2p      uint16
-		wantFastestBlockBroker       string
+		wantFastestBlockSystem       string
 
 		// Spot checks on parsed sub-fields at particular indices.
 		checks []fieldCheck
@@ -48,27 +48,27 @@ func TestParseServerTimings(t *testing.T) {
 			wantIPNSResolveS:             nil,
 			wantFirstConnectS:            fptr(0.206),
 			wantFirstBlockS:              fptr(1.0),
-			wantProviderCountHTTPGateway: 4, // 4 'p' entries, all router=http_gateway
+			wantProviderCountHTTPGateway: 4, // 4 'p' entries, all system=http_gateway
 			wantProviderCountLibp2p:      0,
-			wantFastestBlockBroker:       "trustless_gateway",
+			wantFastestBlockSystem:       "trustless_gateway",
 			checks: []fieldCheck{
 				// Entry 0: i;dur=0
 				{idx: 0, name: "ipfs_resolve", durS: 0},
 				// Entry 1: p;dur=0;desc="h,bagqbeaawn"
-				{idx: 1, name: "provider", durS: 0, router: "http_gateway", providerID: "bagqbeaawn"},
+				{idx: 1, name: "provider", durS: 0, system: "http_gateway", providerID: "bagqbeaawn"},
 				// Entry 7: f;dur=144;desc="l,0"
-				{idx: 7, name: "find_providers", durS: 0.144, router: "libp2p", extra: "0"},
+				{idx: 7, name: "find_providers", durS: 0.144, system: "libp2p", extra: "0"},
 				// Entry 9: c;dur=206;desc="t,bagqbeaa7n,h"
-				{idx: 9, name: "connect", durS: 0.206, broker: "trustless_gateway", providerID: "bagqbeaa7n", transport: "http"},
+				{idx: 9, name: "connect", durS: 0.206, system: "trustless_gateway", providerID: "bagqbeaa7n", transport: "http"},
 				// Entry 10: b;dur=1000;desc="t,bagqbeaa7n,bafybeigoc"
-				{idx: 10, name: "block", durS: 1.0, broker: "trustless_gateway", providerID: "bagqbeaa7n", extra: "bafybeigoc"},
+				{idx: 10, name: "block", durS: 1.0, system: "trustless_gateway", providerID: "bagqbeaa7n", extra: "bafybeigoc"},
 			},
 		},
 		{
 			name:                   "empty",
 			metrics:                nil,
 			wantLen:                0,
-			wantFastestBlockBroker: "",
+			wantFastestBlockSystem: "",
 		},
 		{
 			name:                   "only_resolve_metrics_no_desc",
@@ -77,7 +77,7 @@ func TestParseServerTimings(t *testing.T) {
 			wantDNSLinkResolveS:    fptr(0.012),
 			wantIPFSResolveS:       fptr(0),
 			wantIPNSResolveS:       fptr(0.034),
-			wantFastestBlockBroker: "",
+			wantFastestBlockSystem: "",
 			checks: []fieldCheck{
 				{idx: 0, name: "dnslink_resolve", durS: 0.012},
 				{idx: 1, name: "ipfs_resolve", durS: 0},
@@ -85,12 +85,12 @@ func TestParseServerTimings(t *testing.T) {
 			},
 		},
 		{
-			name: "multiple_blocks_picks_fastest_broker",
+			name: "multiple_blocks_picks_fastest_system",
 			metrics: mustParse(t,
 				`b;dur=500;desc="t,prov1,cidX",b;dur=100;desc="b,prov2,cidY",b;dur=900;desc="t,prov3,cidZ"`),
 			wantLen:                3,
 			wantFirstBlockS:        fptr(0.1),
-			wantFastestBlockBroker: "bitswap",
+			wantFastestBlockSystem: "bitswap",
 		},
 		{
 			name:                         "libp2p_and_http_provider_counts",
@@ -98,14 +98,15 @@ func TestParseServerTimings(t *testing.T) {
 			wantLen:                      3,
 			wantProviderCountHTTPGateway: 1,
 			wantProviderCountLibp2p:      2,
-			wantFastestBlockBroker:       "",
+			wantFastestBlockSystem:       "",
 		},
 		{
 			name:    "unknown_abbrev_passes_through",
 			metrics: mustParse(t, `x;dur=5;desc="z,pid1"`),
 			wantLen: 1,
 			checks: []fieldCheck{
-				// Unknown metric code 'x' and unknown router 'z' pass through verbatim.
+				// Unknown metric code 'x' passes through verbatim. The 'z' system code
+				// is unmapped for any m.Name, so system stays empty (x isn't p/f/c/b).
 				{idx: 0, name: "x", durS: 0.005},
 			},
 		},
@@ -122,8 +123,7 @@ func TestParseServerTimings(t *testing.T) {
 			// ClickHouse enforces on Nested columns on insert.
 			assertLen(t, "NameArr", got.NameArr, tt.wantLen)
 			assertLen(t, "DurSArr", got.DurSArr, tt.wantLen)
-			assertLen(t, "RouterArr", got.RouterArr, tt.wantLen)
-			assertLen(t, "BrokerArr", got.BrokerArr, tt.wantLen)
+			assertLen(t, "SystemArr", got.SystemArr, tt.wantLen)
 			assertLen(t, "ProviderIDArr", got.ProviderIDArr, tt.wantLen)
 			assertLen(t, "TransportArr", got.TransportArr, tt.wantLen)
 			assertLen(t, "ExtraArr", got.ExtraArr, tt.wantLen)
@@ -140,8 +140,8 @@ func TestParseServerTimings(t *testing.T) {
 			if got.ProviderCountLibp2p != tt.wantProviderCountLibp2p {
 				t.Errorf("ProviderCountLibp2p: got %d, want %d", got.ProviderCountLibp2p, tt.wantProviderCountLibp2p)
 			}
-			if got.FastestBlockBroker != tt.wantFastestBlockBroker {
-				t.Errorf("FastestBlockBroker: got %q, want %q", got.FastestBlockBroker, tt.wantFastestBlockBroker)
+			if got.FastestBlockSystem != tt.wantFastestBlockSystem {
+				t.Errorf("FastestBlockSystem: got %q, want %q", got.FastestBlockSystem, tt.wantFastestBlockSystem)
 			}
 
 			for _, c := range tt.checks {
@@ -168,8 +168,7 @@ type fieldCheck struct {
 	idx        int
 	name       string
 	durS       float64
-	router     string
-	broker     string
+	system     string
 	providerID string
 	transport  string
 	extra      string
@@ -186,11 +185,8 @@ func (c fieldCheck) assert(t *testing.T, got ServerTimingRow) {
 	if !floatsClose(got.DurSArr[c.idx], c.durS) {
 		t.Errorf("idx %d durS: got %v, want %v", c.idx, got.DurSArr[c.idx], c.durS)
 	}
-	if got.RouterArr[c.idx] != c.router {
-		t.Errorf("idx %d router: got %q, want %q", c.idx, got.RouterArr[c.idx], c.router)
-	}
-	if got.BrokerArr[c.idx] != c.broker {
-		t.Errorf("idx %d broker: got %q, want %q", c.idx, got.BrokerArr[c.idx], c.broker)
+	if got.SystemArr[c.idx] != c.system {
+		t.Errorf("idx %d system: got %q, want %q", c.idx, got.SystemArr[c.idx], c.system)
 	}
 	if got.ProviderIDArr[c.idx] != c.providerID {
 		t.Errorf("idx %d providerID: got %q, want %q", c.idx, got.ProviderIDArr[c.idx], c.providerID)

--- a/pkg/sw/server_timing_test.go
+++ b/pkg/sw/server_timing_test.go
@@ -1,0 +1,243 @@
+package sw
+
+import (
+	"testing"
+
+	servertiming "github.com/dennis-tra/go-server-timing"
+)
+
+func TestParseServerTimings(t *testing.T) {
+	t.Parallel()
+
+	// Header from helia-verified-fetch README. Parsing it with the servertiming
+	// library gives us the exact structure the service worker emits in the wild.
+	const readmeHeader = `i;dur=0,p;dur=0;desc="h,bagqbeaawn",p;dur=0;desc="h,bagqbeaawn",` +
+		`p;dur=1;desc="h,bagqbeaa7n",p;dur=1;desc="h,bagqbeaa7n",` +
+		`f;dur=1;desc="h,4",f;dur=1;desc="h,4",f;dur=144;desc="l,0",f;dur=144;desc="l,0",` +
+		`c;dur=206;desc="t,bagqbeaa7n,h",b;dur=1000;desc="t,bagqbeaa7n,bafybeigoc"`
+
+	parsed, err := servertiming.ParseHeader(readmeHeader)
+	if err != nil {
+		t.Fatalf("parse readme header: %v", err)
+	}
+	readmeMetrics := parsed.Metrics()
+
+	tests := []struct {
+		name    string
+		metrics []*servertiming.Metric
+
+		wantLen                      int
+		wantIPFSResolveS             *float64
+		wantDNSLinkResolveS          *float64
+		wantIPNSResolveS             *float64
+		wantFirstConnectS            *float64
+		wantFirstBlockS              *float64
+		wantProviderCountHTTPGateway uint16
+		wantProviderCountLibp2p      uint16
+		wantFastestBlockBroker       string
+
+		// Spot checks on parsed sub-fields at particular indices.
+		checks []fieldCheck
+	}{
+		{
+			name:                         "readme_example",
+			metrics:                      readmeMetrics,
+			wantLen:                      11,
+			wantIPFSResolveS:             fptr(0),
+			wantDNSLinkResolveS:          nil,
+			wantIPNSResolveS:             nil,
+			wantFirstConnectS:            fptr(0.206),
+			wantFirstBlockS:              fptr(1.0),
+			wantProviderCountHTTPGateway: 4, // 4 'p' entries, all router=http_gateway
+			wantProviderCountLibp2p:      0,
+			wantFastestBlockBroker:       "trustless_gateway",
+			checks: []fieldCheck{
+				// Entry 0: i;dur=0
+				{idx: 0, name: "ipfs_resolve", durS: 0},
+				// Entry 1: p;dur=0;desc="h,bagqbeaawn"
+				{idx: 1, name: "provider", durS: 0, router: "http_gateway", providerID: "bagqbeaawn"},
+				// Entry 7: f;dur=144;desc="l,0"
+				{idx: 7, name: "find_providers", durS: 0.144, router: "libp2p", extra: "0"},
+				// Entry 9: c;dur=206;desc="t,bagqbeaa7n,h"
+				{idx: 9, name: "connect", durS: 0.206, broker: "trustless_gateway", providerID: "bagqbeaa7n", transport: "http"},
+				// Entry 10: b;dur=1000;desc="t,bagqbeaa7n,bafybeigoc"
+				{idx: 10, name: "block", durS: 1.0, broker: "trustless_gateway", providerID: "bagqbeaa7n", extra: "bafybeigoc"},
+			},
+		},
+		{
+			name:                   "empty",
+			metrics:                nil,
+			wantLen:                0,
+			wantFastestBlockBroker: "",
+		},
+		{
+			name:                   "only_resolve_metrics_no_desc",
+			metrics:                mustParse(t, `d;dur=12,i;dur=0,n;dur=34`),
+			wantLen:                3,
+			wantDNSLinkResolveS:    fptr(0.012),
+			wantIPFSResolveS:       fptr(0),
+			wantIPNSResolveS:       fptr(0.034),
+			wantFastestBlockBroker: "",
+			checks: []fieldCheck{
+				{idx: 0, name: "dnslink_resolve", durS: 0.012},
+				{idx: 1, name: "ipfs_resolve", durS: 0},
+				{idx: 2, name: "ipns_resolve", durS: 0.034},
+			},
+		},
+		{
+			name: "multiple_blocks_picks_fastest_broker",
+			metrics: mustParse(t,
+				`b;dur=500;desc="t,prov1,cidX",b;dur=100;desc="b,prov2,cidY",b;dur=900;desc="t,prov3,cidZ"`),
+			wantLen:                3,
+			wantFirstBlockS:        fptr(0.1),
+			wantFastestBlockBroker: "bitswap",
+		},
+		{
+			name:                         "libp2p_and_http_provider_counts",
+			metrics:                      mustParse(t, `p;dur=1;desc="h,a",p;dur=2;desc="l,b",p;dur=3;desc="l,c"`),
+			wantLen:                      3,
+			wantProviderCountHTTPGateway: 1,
+			wantProviderCountLibp2p:      2,
+			wantFastestBlockBroker:       "",
+		},
+		{
+			name:    "unknown_abbrev_passes_through",
+			metrics: mustParse(t, `x;dur=5;desc="z,pid1"`),
+			wantLen: 1,
+			checks: []fieldCheck{
+				// Unknown metric code 'x' and unknown router 'z' pass through verbatim.
+				{idx: 0, name: "x", durS: 0.005},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ParseServerTimings(tt.metrics)
+
+			// All parallel slices must have equal length — this is a hard invariant
+			// ClickHouse enforces on Nested columns on insert.
+			assertLen(t, "NameArr", got.NameArr, tt.wantLen)
+			assertLen(t, "DurSArr", got.DurSArr, tt.wantLen)
+			assertLen(t, "RouterArr", got.RouterArr, tt.wantLen)
+			assertLen(t, "BrokerArr", got.BrokerArr, tt.wantLen)
+			assertLen(t, "ProviderIDArr", got.ProviderIDArr, tt.wantLen)
+			assertLen(t, "TransportArr", got.TransportArr, tt.wantLen)
+			assertLen(t, "ExtraArr", got.ExtraArr, tt.wantLen)
+
+			assertPtrFloat(t, "IPFSResolveS", got.IPFSResolveS, tt.wantIPFSResolveS)
+			assertPtrFloat(t, "DNSLinkResolveS", got.DNSLinkResolveS, tt.wantDNSLinkResolveS)
+			assertPtrFloat(t, "IPNSResolveS", got.IPNSResolveS, tt.wantIPNSResolveS)
+			assertPtrFloat(t, "FirstConnectS", got.FirstConnectS, tt.wantFirstConnectS)
+			assertPtrFloat(t, "FirstBlockS", got.FirstBlockS, tt.wantFirstBlockS)
+
+			if got.ProviderCountHTTPGateway != tt.wantProviderCountHTTPGateway {
+				t.Errorf("ProviderCountHTTPGateway: got %d, want %d", got.ProviderCountHTTPGateway, tt.wantProviderCountHTTPGateway)
+			}
+			if got.ProviderCountLibp2p != tt.wantProviderCountLibp2p {
+				t.Errorf("ProviderCountLibp2p: got %d, want %d", got.ProviderCountLibp2p, tt.wantProviderCountLibp2p)
+			}
+			if got.FastestBlockBroker != tt.wantFastestBlockBroker {
+				t.Errorf("FastestBlockBroker: got %q, want %q", got.FastestBlockBroker, tt.wantFastestBlockBroker)
+			}
+
+			for _, c := range tt.checks {
+				c.assert(t, got)
+			}
+		})
+	}
+}
+
+func TestParseServerTimings_NilMetricSkipped(t *testing.T) {
+	t.Parallel()
+
+	// A nil entry in the slice should be skipped without panic or length skew.
+	m := &servertiming.Metric{Name: "i"}
+	got := ParseServerTimings([]*servertiming.Metric{nil, m, nil})
+	if len(got.NameArr) != 1 || got.NameArr[0] != "ipfs_resolve" {
+		t.Errorf("expected exactly one 'ipfs_resolve' entry, got %v", got.NameArr)
+	}
+}
+
+// --- helpers ---
+
+type fieldCheck struct {
+	idx        int
+	name       string
+	durS       float64
+	router     string
+	broker     string
+	providerID string
+	transport  string
+	extra      string
+}
+
+func (c fieldCheck) assert(t *testing.T, got ServerTimingRow) {
+	t.Helper()
+	if c.idx >= len(got.NameArr) {
+		t.Fatalf("idx %d out of range (len=%d)", c.idx, len(got.NameArr))
+	}
+	if got.NameArr[c.idx] != c.name {
+		t.Errorf("idx %d name: got %q, want %q", c.idx, got.NameArr[c.idx], c.name)
+	}
+	if !floatsClose(got.DurSArr[c.idx], c.durS) {
+		t.Errorf("idx %d durS: got %v, want %v", c.idx, got.DurSArr[c.idx], c.durS)
+	}
+	if got.RouterArr[c.idx] != c.router {
+		t.Errorf("idx %d router: got %q, want %q", c.idx, got.RouterArr[c.idx], c.router)
+	}
+	if got.BrokerArr[c.idx] != c.broker {
+		t.Errorf("idx %d broker: got %q, want %q", c.idx, got.BrokerArr[c.idx], c.broker)
+	}
+	if got.ProviderIDArr[c.idx] != c.providerID {
+		t.Errorf("idx %d providerID: got %q, want %q", c.idx, got.ProviderIDArr[c.idx], c.providerID)
+	}
+	if got.TransportArr[c.idx] != c.transport {
+		t.Errorf("idx %d transport: got %q, want %q", c.idx, got.TransportArr[c.idx], c.transport)
+	}
+	if got.ExtraArr[c.idx] != c.extra {
+		t.Errorf("idx %d extra: got %q, want %q", c.idx, got.ExtraArr[c.idx], c.extra)
+	}
+}
+
+func mustParse(t *testing.T, header string) []*servertiming.Metric {
+	t.Helper()
+	h, err := servertiming.ParseHeader(header)
+	if err != nil {
+		t.Fatalf("parse header %q: %v", header, err)
+	}
+	return h.Metrics()
+}
+
+func fptr(v float64) *float64 { return &v }
+
+func assertLen[T any](t *testing.T, label string, s []T, want int) {
+	t.Helper()
+	if len(s) != want {
+		t.Errorf("%s length: got %d, want %d", label, len(s), want)
+	}
+}
+
+func assertPtrFloat(t *testing.T, label string, got, want *float64) {
+	t.Helper()
+	switch {
+	case got == nil && want == nil:
+		return
+	case got == nil || want == nil:
+		t.Errorf("%s: got %v, want %v", label, got, want)
+	case !floatsClose(*got, *want):
+		t.Errorf("%s: got %v, want %v", label, *got, *want)
+	}
+}
+
+func floatsClose(a, b float64) bool {
+	const eps = 1e-9
+	d := a - b
+	if d < 0 {
+		d = -d
+	}
+	return d < eps
+}

--- a/pkg/sw/serviceworker.go
+++ b/pkg/sw/serviceworker.go
@@ -20,6 +20,7 @@ import (
 	"github.com/chromedp/cdproto/serviceworker"
 	"github.com/chromedp/cdproto/target"
 	"github.com/chromedp/chromedp"
+	servertiming "github.com/dennis-tra/go-server-timing"
 	"github.com/ipfs/boxo/routing/http/types"
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -134,7 +135,7 @@ type swProbeResult struct {
 	GatewayCacheStatus *string
 
 	// Server timing data (from final response)
-	ServerTimings        map[string]ServerTiming
+	ServerTimings        []*servertiming.Metric
 	DelegatedRouterTTFB  time.Duration
 	TrustlessGatewayTTFB time.Duration
 
@@ -469,7 +470,7 @@ func (p *swProbe) buildProbeResult() *swProbeResult {
 	defer p.listenMu.Unlock()
 
 	result := &swProbeResult{
-		ServerTimings:        make(map[string]ServerTiming),
+		ServerTimings:        make([]*servertiming.Metric, 0),
 		DelegatedRouterTTFB:  0,
 		TrustlessGatewayTTFB: 0,
 	}
@@ -620,8 +621,13 @@ func (p *swProbe) buildProbeResult() *swProbeResult {
 	}
 
 	// Parse server-timing header
-	if serverTimingHeader, ok := finalResp.Headers["server-timing"].(string); ok {
-		result.ServerTimings = parseServerTiming(serverTimingHeader)
+	if serverTimingHeader, ok := finalResp.Headers[strings.ToLower(servertiming.HeaderName)].(string); ok {
+		stHdr, err := servertiming.ParseHeader(serverTimingHeader)
+		if err != nil {
+			slog.Warn("Failed to parse server-timing header", "err", err)
+		}
+		// stHdr is always non-nil, even if there was an error
+		result.ServerTimings = stHdr.Metrics()
 	}
 
 	// Calculate timing metrics using ResourceTiming exclusively
@@ -775,63 +781,4 @@ func (r *swProbe) handleResponseReceived(e *network.EventResponseReceived) {
 
 	trace.currentURL = e.Response.URL
 	trace.responses = append(trace.responses, e.Response)
-}
-
-type ServerTiming struct {
-	Name  string
-	Value time.Duration
-	Desc  string
-	Extra map[string]string
-}
-
-// parseServerTiming parses a server-timing header into a map of serverTiming.
-// Each entry represents a metric with its name, duration, description, and extras.
-// Parses strings like: custom-metric;dur=123.45;desc="My custom metric"
-func parseServerTiming(raw string) map[string]ServerTiming {
-	serverTimings := map[string]ServerTiming{}
-
-	metrics := strings.Split(raw, ",")
-	for _, metric := range metrics {
-		fields := strings.Split(metric, ";")
-		if len(fields) < 2 {
-			continue
-		}
-
-		st := ServerTiming{
-			Name:  strings.TrimSpace(fields[0]),
-			Extra: make(map[string]string),
-		}
-
-		for _, field := range fields[1:] {
-			kv := strings.Split(field, "=")
-			if len(kv) != 2 {
-				continue
-			}
-
-			switch kv[0] {
-			case "dur":
-				dur, err := time.ParseDuration(kv[1] + "ms")
-				if err != nil {
-					continue
-				}
-				st.Value = dur
-			case "desc":
-				unquote, err := strconv.Unquote(kv[1])
-				if err != nil {
-					continue
-				}
-				st.Desc = unquote
-			default:
-				unquote, err := strconv.Unquote(kv[1])
-				if err != nil {
-					continue
-				}
-
-				st.Extra[kv[0]] = unquote
-			}
-		}
-		serverTimings[st.Name] = st
-	}
-
-	return serverTimings
 }

--- a/pkg/sw/serviceworker_test.go
+++ b/pkg/sw/serviceworker_test.go
@@ -9,53 +9,8 @@ import (
 	"github.com/chromedp/cdproto/page"
 	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
-
-func Test_parseServerTiming(t *testing.T) {
-	tests := []struct {
-		raw  string
-		want map[string]ServerTiming
-	}{
-		{
-			raw: "ipfs.resolve;dur=0.0;desc=\"\",exporter-dir;dur=0.0;desc=\"\"",
-			want: map[string]ServerTiming{
-				"ipfs.resolve": {Name: "ipfs.resolve", Value: 0, Desc: "", Extra: map[string]string{}},
-				"exporter-dir": {Name: "exporter-dir", Value: 0, Desc: "", Extra: map[string]string{}},
-			},
-		},
-		{
-			raw: "custom-metric;dur=123.45;desc=\"My custom metric\"",
-			want: map[string]ServerTiming{
-				"custom-metric": {Name: "custom-metric", Value: 123450 * time.Microsecond, Desc: "My custom metric", Extra: map[string]string{}},
-			},
-		},
-		{
-			raw: "cpu;dur=2.4",
-			want: map[string]ServerTiming{
-				"cpu": {Name: "cpu", Value: 2400 * time.Microsecond, Extra: map[string]string{}},
-			},
-		},
-		{
-			raw: "cache;desc=\"Cache Read\";dur=23.2",
-			want: map[string]ServerTiming{
-				"cache": {Name: "cache", Value: 23200 * time.Microsecond, Desc: "Cache Read", Extra: map[string]string{}},
-			},
-		},
-		{
-			raw: "db;dur=53, app;dur=47.2",
-			want: map[string]ServerTiming{
-				"db":  {Name: "db", Value: 53000 * time.Microsecond, Extra: map[string]string{}},
-				"app": {Name: "app", Value: 47200 * time.Microsecond, Extra: map[string]string{}},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.raw, func(t *testing.T) {
-			got := parseServerTiming(tt.raw)
-			assert.Equalf(t, tt.want, got, "parseServerTiming(%v)", tt.raw)
-		})
-	}
-}
 
 func TestSwProbe_IsProbeDone(t *testing.T) {
 	c, err := cid.Decode("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi")
@@ -202,12 +157,13 @@ func TestSwProbe_BuildProbeResult(t *testing.T) {
 	// TotalTTFB: (1001-1000)*1000 + 50 = 1050ms
 	assert.Equal(t, 1050*time.Millisecond, result.TotalTTFB)
 
-	// Server Timing
-	assert.Contains(t, result.ServerTimings, "ipfs.resolve")
-	assert.Equal(t, 100*time.Millisecond, result.ServerTimings["ipfs.resolve"].Value)
-
 	// Trustless Gateway TTFB
 	assert.Equal(t, 20*time.Millisecond, result.TrustlessGatewayTTFB)
+
+	// Server Timing
+	require.Len(t, result.ServerTimings, 1)
+	assert.Equal(t, "ipfs.resolve", result.ServerTimings[0].Name)
+	assert.Equal(t, 100*time.Millisecond, result.ServerTimings[0].Duration)
 }
 
 func TestSwProbe_DelegatedRouterStatus(t *testing.T) {


### PR DESCRIPTION
Uses https://github.com/dennis-tra/go-server-timing to parse the server timing header values. The values are also stored differently in our db to capture repeated metric names in the header.